### PR TITLE
Bump TLBC version to 1.4.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,5 @@
 #FROM trustlines/tlbc-node:release21542
-FROM trustlines/tlbc-node@sha256:2fb59b66785682d5b2507a9b540df8f4e7544ed6e535f46aa916e3f02e95c06a
+FROM trustlines/tlbc-node@sha256:1bb14a2ccfd4f31d196489e996bf2f816465f40f042364473a58bcdc4aff05d5
 
 WORKDIR /config/custom/keys/tlbc
 


### PR DESCRIPTION
**What needs to be noted.**

We are currently experiencing a fork and validators end up on the wrong chain. Even after updating their chainspec file. 
It looks like a bug/feature of OpenEtehreum. Since validators didn't receive the correct chainspec they were on a different chain, unfortunately even after applying the correct chainspec OE seems to think that they are on the correct chain, as the chains is maybe the longest. 

What helped to get those unstuck nodes on the correct chain was to drop the open ethereum database and let the nodes resync. Then they end up on the correct chain.